### PR TITLE
Support KeyID token option for Container Signatures

### DIFF
--- a/server/signedcontainer/verify.go
+++ b/server/signedcontainer/verify.go
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/GoogleCloudPlatform/confidential-space/server/signedcontainer/internal/convert"
@@ -165,4 +166,17 @@ func createPublicKeysetHandle(publicKey []byte, sigAlg signingAlgorithm) (*keyse
 	default:
 		return nil, fmt.Errorf("unsupported signing algorithm: %v", sigAlg)
 	}
+}
+
+// FilterByKeyIDs returns the elements in 'signatures' with key IDs present in 'kids'.
+// If kids is nil or empty, an empty list will be returned.
+func FilterByKeyIDs(signatures []*VerifiedSignature, kids []string) []*VerifiedSignature {
+	filteredSigs := []*VerifiedSignature{}
+	for _, sig := range signatures {
+		if slices.Contains(kids, sig.KeyID) {
+			filteredSigs = append(filteredSigs, sig)
+		}
+	}
+
+	return filteredSigs
 }

--- a/server/signedcontainer/verify_test.go
+++ b/server/signedcontainer/verify_test.go
@@ -422,3 +422,75 @@ func TestCreatePublicKeysetHandle(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterByKeyID(t *testing.T) {
+	testSignatures := []*VerifiedSignature{
+		{
+			Signature: "sig0",
+			KeyID:     "kid0",
+			Alg:       "RS256",
+		},
+		{
+			Signature: "sig1",
+			KeyID:     "kid1",
+			Alg:       "RS256",
+		},
+		{
+			Signature: "sig2",
+			KeyID:     "kid2",
+			Alg:       "RS256",
+		},
+	}
+
+	testcases := []struct {
+		name               string
+		keyIDs             []string
+		expectedSignatures []*VerifiedSignature
+	}{
+		{
+			name: "all keyIDs present",
+			keyIDs: []string{
+				testSignatures[0].KeyID,
+				testSignatures[1].KeyID,
+				testSignatures[2].KeyID,
+			},
+			expectedSignatures: testSignatures,
+		},
+		{
+			name:               "no expected keyIDs present",
+			keyIDs:             []string{"a-different-key-id"},
+			expectedSignatures: []*VerifiedSignature{},
+		},
+		{
+			name: "some keyIDs present",
+			keyIDs: []string{
+				testSignatures[0].KeyID,
+				testSignatures[2].KeyID,
+			},
+			expectedSignatures: []*VerifiedSignature{
+				testSignatures[0],
+				testSignatures[2],
+			},
+		},
+		{
+			name:               "empty keyIDs",
+			keyIDs:             []string{},
+			expectedSignatures: []*VerifiedSignature{},
+		},
+		{
+			name:               "nil keyIDs",
+			keyIDs:             nil,
+			expectedSignatures: []*VerifiedSignature{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			filteredSigs := FilterByKeyIDs(testSignatures, tc.keyIDs)
+
+			if diff := cmp.Diff(filteredSigs, tc.expectedSignatures); diff != "" {
+				t.Errorf("FilterByKeyIDs did not return expected signatures: %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://github.com/google/go-tpm-tools/pull/515 introduces an option to filter Container Image Signatures by Key ID. This adds a `FilterByKeyIds` function that implements this filtering. Said function should be called on the `*VerifiedSignatures` list returned by `signedcontainer.Verify`

Usage:
```
result, err := signedcontainer.Verify("digest", signatures)

keyIDs := tokentypeOpts.AWSPrincipalTags.SignedContainer.keyIDs
if len(keyIDs) > 0 {
    filteredSigs := signedcontainer.FilterByKeyIDs(results.Verified, keyIDs)
}
``