### PR TITLE
Fix a typo in uwear/workload.go

### DIFF
--- a/codelabs/health_data_analysis_codelab/src/uwear/workload.go
+++ b/codelabs/health_data_analysis_codelab/src/uwear/workload.go
@@ -65,7 +65,7 @@ const (
 		input.eat_nonce == "%s"
 	}
 	`
-	regoQuery = "allow = data.confidential_space.allow; hw_verified = data.confidential_space.hw_verified; image__digest_verified = data.confidential_space.image_digest_verified; audience_verified = data.confidential_space.audience_verified; nonce_verified = data.confidential_space.nonce_verified; issuer_verified = data.confidential_space.issuer_verified; secboot_verified = data.confidential_space.secboot_verified; sw_name_verified = data.confidential_space.sw_name_verified"
+	regoQuery = "allow = data.confidential_space.allow; hw_verified = data.confidential_space.hw_verified; image_digest_verified = data.confidential_space.image_digest_verified; audience_verified = data.confidential_space.audience_verified; nonce_verified = data.confidential_space.nonce_verified; issuer_verified = data.confidential_space.issuer_verified; secboot_verified = data.confidential_space.secboot_verified; sw_name_verified = data.confidential_space.sw_name_verified"
 )
 
 func readFile(filename string) ([]byte, error) {


### PR DESCRIPTION
I believe that image_digest_verified wasn't used in this particular example, but since people usually start their Confidential Space project using uwear/usleep example, it helps to correct this.