### PR TITLE
feat: Add multi-container support for CEL parsing

### DIFF
--- a/server/coscel/cos_tlv.go
+++ b/server/coscel/cos_tlv.go
@@ -48,6 +48,7 @@ const (
 	MemoryMonitorType
 	GpuCCModeType
 	GPUDeviceAttestationBindingType
+	ContainerSeparatorType
 )
 
 // COSTLV is a specific event type created for the COS (Google Container-Optimized OS),

--- a/server/extract/cos_state.go
+++ b/server/extract/cos_state.go
@@ -52,12 +52,20 @@ func getCOSStateFromCEL(rawCanonicalEventLog []byte, register register.MRBank, t
 // VerifiedCOSState returns the AttestedCosState from the given event log.
 func VerifiedCOSState(eventLog cel.CEL, registerType uint8, opts Options) (*pb.AttestedCosState, error) {
 	cosState := &pb.AttestedCosState{}
-	cosState.Container = &pb.ContainerState{}
+
+	// Initialize a default container (handles backward compatibility for old single-container logs)
+	defaultContainer := &pb.ContainerState{
+		Args:              make([]string, 0),
+		EnvVars:           make(map[string]string),
+		OverriddenEnvVars: make(map[string]string),
+	}
+
+	cosState.Containers = []*pb.ContainerState{defaultContainer}
+
+	currentContainer := defaultContainer
+
 	cosState.HealthMonitoring = &pb.HealthMonitoringState{}
 	cosState.GpuDeviceState = &pb.GpuDeviceState{}
-	cosState.Container.Args = make([]string, 0)
-	cosState.Container.EnvVars = make(map[string]string)
-	cosState.Container.OverriddenEnvVars = make(map[string]string)
 
 	seenSeparator := false
 	for _, record := range eventLog.Records() {
@@ -99,50 +107,61 @@ func VerifiedCOSState(eventLog cel.CEL, registerType uint8, opts Options) (*pb.A
 		}
 
 		switch cosTlv.EventType {
+		case coscel.ContainerSeparatorType:
+			// If default container is already populated with an image (meaning we are on 2nd container)
+			// Or Create a new one every time we see this event
+			if currentContainer.GetImageReference() != "" || currentContainer.GetImageDigest() != "" {
+				currentContainer = &pb.ContainerState{
+					Args:              make([]string, 0),
+					EnvVars:           make(map[string]string),
+					OverriddenEnvVars: make(map[string]string),
+				}
+				cosState.Containers = append(cosState.Containers, currentContainer)
+			}
 		case coscel.ImageRefType:
-			if cosState.Container.GetImageReference() != "" {
+			if currentContainer.GetImageReference() != "" {
 				return nil, fmt.Errorf("found more than one ImageRef event")
 			}
-			cosState.Container.ImageReference = string(cosTlv.EventContent)
+			currentContainer.ImageReference = string(cosTlv.EventContent)
 
 		case coscel.ImageDigestType:
-			if cosState.Container.GetImageDigest() != "" {
+			if currentContainer.GetImageDigest() != "" {
 				return nil, fmt.Errorf("found more than one ImageDigest event")
 			}
-			cosState.Container.ImageDigest = string(cosTlv.EventContent)
+			currentContainer.ImageDigest = string(cosTlv.EventContent)
 
 		case coscel.RestartPolicyType:
 			restartPolicy, ok := pb.RestartPolicy_value[string(cosTlv.EventContent)]
 			if !ok {
 				return nil, fmt.Errorf("unknown restart policy in COS eventlog: %s", string(cosTlv.EventContent))
 			}
-			cosState.Container.RestartPolicy = pb.RestartPolicy(restartPolicy)
+			currentContainer.RestartPolicy = pb.RestartPolicy(restartPolicy)
 
 		case coscel.ImageIDType:
-			if cosState.Container.GetImageId() != "" {
+			if currentContainer.GetImageId() != "" {
 				return nil, fmt.Errorf("found more than one ImageId event")
 			}
-			cosState.Container.ImageId = string(cosTlv.EventContent)
+			currentContainer.ImageId = string(cosTlv.EventContent)
 
 		case coscel.EnvVarType:
 			envName, envVal, err := coscel.ParseEnvVar(string(cosTlv.EventContent))
 			if err != nil {
 				return nil, err
 			}
-			cosState.Container.EnvVars[envName] = envVal
+			currentContainer.EnvVars[envName] = envVal
 
 		case coscel.ArgType:
-			cosState.Container.Args = append(cosState.Container.Args, string(cosTlv.EventContent))
+			currentContainer.Args = append(currentContainer.Args, string(cosTlv.EventContent))
 
 		case coscel.OverrideArgType:
-			cosState.Container.OverriddenArgs = append(cosState.Container.OverriddenArgs, string(cosTlv.EventContent))
+			currentContainer.OverriddenArgs = append(currentContainer.OverriddenArgs, string(cosTlv.EventContent))
 
 		case coscel.OverrideEnvType:
 			envName, envVal, err := coscel.ParseEnvVar(string(cosTlv.EventContent))
 			if err != nil {
 				return nil, err
 			}
-			cosState.Container.OverriddenEnvVars[envName] = envVal
+			currentContainer.OverriddenEnvVars[envName] = envVal
 		case coscel.LaunchSeparatorType:
 			seenSeparator = true
 		case coscel.MemoryMonitorType:


### PR DESCRIPTION
### Background
Currently, the `AttestedCosState` parsing logic is designed to handle a single container per execution. As part of an ongoing effort to support launching multiple containers natively within Confidential Space, the `go-tpm-tools` launcher will soon emit a sequence of container measurements separated by a new `ContainerSeparatorType` event. 

This PR updates the Canonical Event Log (CEL) parsing logic to recognize these separator events and accurately populate a list of containers.

### Changes Made
* **Added `ContainerSeparatorType`:** Introduced `ContainerSeparatorType` to `server/coscel/cos_tlv.go` to stay perfectly in sync with the event definitions emitted by the `go-tpm-tools` Attestation Agent. 
* **Refactored `VerifiedCOSState`:** Updated the event replay loop in `server/extract/cos_state.go` to handle a dynamic `Containers` slice.
* **Cursor Parsing Pattern:** Implemented logic where encountering a `ContainerSeparatorType` instantiates a new, default `ContainerState` and appends it to the list. Subsequent container-specific measurements (like `ImageRefType`, `ImageDigestType`, `ArgType`, etc.) are now correctly applied to the currently "active" container in the iteration.

### Testing
* Verified locally by executing the modified parser against a multi-container CEL generated by an updated `go-tpm-tools` launcher using the local fake verifier.
